### PR TITLE
feat: Add is_daemon flag, to allow session renew to be runned as a Daemon

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -5,6 +5,8 @@ jobs:
   Syntax-Lint:
     runs-on: ubuntu-latest
     steps:
+      - name: Update python pip3
+        run: "sudo apt update && sudo apt install --only-upgrade python3-pip && sudo apt remove python3-packaging"
       - name: Install python prerequisites
         run: "sudo pip3 install tox"
       - name: Checkout repository
@@ -15,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
+      - name: Update python pip3
+        run: "sudo apt update && sudo apt install --only-upgrade python3-pip && sudo apt remove python3-packaging"
       - name: Install python prerequisites
         run: "sudo pip3 install tox"
       - name: Checkout repository

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -5,23 +5,27 @@ jobs:
   Syntax-Lint:
     runs-on: ubuntu-latest
     steps:
-      - name: Update python pip3
-        run: "sudo apt update && sudo apt install --only-upgrade python3-pip && sudo apt remove python3-packaging"
-      - name: Install python prerequisites
-        run: "sudo pip3 install tox"
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+          cache: 'pip'
+      - name: Install python prerequisites
+        run: "python -m pip install --upgrade pip tox"
       - name: Perform syntax lint
         run: "cd ${{ github.workspace }} && tox -e lint"
   Safety-Checks:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - name: Update python pip3
-        run: "sudo apt update && sudo apt install --only-upgrade python3-pip && sudo apt remove python3-packaging"
-      - name: Install python prerequisites
-        run: "sudo pip3 install tox"
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+          cache: 'pip'
+      - name: Install python prerequisites
+        run: "python -m pip install --upgrade pip tox"
       - name: Perform safety checks
         run: "cd ${{ github.workspace }} && tox -e safety"

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -7,7 +7,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - name: Setup Python
+        uses: actions/setup-python@v6
         with:
           python-version: '3.14'
           cache: 'pip'
@@ -21,7 +22,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - name: Setup Python
+        uses: actions/setup-python@v6
         with:
           python-version: '3.14'
           cache: 'pip'

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_version: [35, 36, 37, 38, 39]
+        python_version: [35, 36, 38, 310, 312, 314]
     steps:
       - name: Set up Docker Compose
         uses: docker/setup-compose-action@v1

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -10,8 +10,10 @@ jobs:
       matrix:
         python_version: [35, 36, 37, 38, 39]
     steps:
-      - name: Install python prerequisites
-        run: "sudo pip3 install docker-compose"
+      - name: Set up Docker Compose
+        uses: docker/setup-compose-action@v1
+        with:
+          version: latest
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Perform integration tests for python version ${{ matrix.python_version }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -15,6 +15,6 @@ jobs:
         with:
           version: latest
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Perform integration tests for python version ${{ matrix.python_version }}
         run: "cd ${{ github.workspace }} && docker compose run --rm integration_tests_py${{ matrix.python_version }}"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -17,4 +17,4 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Perform integration tests for python version ${{ matrix.python_version }}
-        run: "cd ${{ github.workspace }} && docker-compose run --rm integration_tests_py${{ matrix.python_version }}"
+        run: "cd ${{ github.workspace }} && docker compose run --rm integration_tests_py${{ matrix.python_version }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG PYTHON_VERSION
-FROM python:$PYTHON_VERSION-alpine
+FROM python:${PYTHON_VERSION}-alpine
 
 RUN apk add bash
 RUN pip install tox

--- a/consul_lib/lock.py
+++ b/consul_lib/lock.py
@@ -40,13 +40,14 @@ class Lock:
     def reset_session(self):
         self.session = None
 
-    def acquire(self, *, blocking=True, wait=None):
+    def acquire(self, *, blocking=True, wait=None, is_daemon=False):
         """
         :param blocking: Wait for someone else or release the Lock. Default True.
                          In long running programs this is the best solution.
                          Using consul from a web application should not block, but warn.
                          Take care to .close() when you are done.
         :param wait: Maximum duration to wait for a key change (e.g. 10s)
+        :paparm is_daemon: Flag to allow consul session renwewal to be run as a daemon. Default False
         """
         # Create a session with a ttl of 60s.
         # So it is possible to find broken clients.
@@ -63,7 +64,7 @@ class Lock:
                 self.session_renewer._session = self.session
             else:
                 LOG.debug("Starting session_renewer.")
-                self.session_renewer = SessionRenewer(self.session, self._con)
+                self.session_renewer = SessionRenewer(self.session, self._con, is_daemon=is_daemon)
                 self.session_renewer.start()
         while not self._con.kv.put(str(self._path), self._payload, acquire=self.session):
             # getting the current index …

--- a/consul_lib/semaphore.py
+++ b/consul_lib/semaphore.py
@@ -10,7 +10,7 @@ LOG = logging.getLogger(__name__)
 
 class Semaphore:
 
-    def __init__(self, con, prefix, size, *, session=None):
+    def __init__(self, con, prefix, size, is_daemon=False, *, session=None):
         """
         Context manager to use consul session to create a semaphore.
         Have a look at: https://www.consul.io/docs/guides/semaphore.html
@@ -35,7 +35,7 @@ class Semaphore:
         # If a Holder fails, without cleanup, it would stuck in Holders.
         # With a session with, ttl and renew of this session, broken
         # clients can be detected and removed from Holders.
-        self.session_renewer = SessionRenewer(self.session, con)
+        self.session_renewer = SessionRenewer(self.session, con, is_daemon=is_daemon)
         self.session_renewer.start()
         self._con = con
         self.prefix = Path(prefix)

--- a/consul_lib/session.py
+++ b/consul_lib/session.py
@@ -6,11 +6,12 @@ LOG = logging.getLogger(__name__)
 
 
 class SessionRenewer(threading.Thread):
-    def __init__(self, session, con, *args, **kwargs):
+    def __init__(self, session, con, is_daemon=False, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._session = session
         self._con = con
         self._finished = False
+        self.daemon = is_daemon
 
     def run(self):
         """ Renew the session in a 5 second interval """
@@ -31,7 +32,7 @@ class SessionRenewer(threading.Thread):
 
 class LockMonitor(threading.Thread):
     """Fires event when lock is lost."""
-    def __init__(self, lock, retries=2, retry_time=2, event=None, *args, **kwargs):
+    def __init__(self, lock, retries=2, retry_time=2, event=None, is_daemon=False, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._finished = False
         self._lock = lock
@@ -39,6 +40,7 @@ class LockMonitor(threading.Thread):
         self._retries = retries
         self._event = event
         self._retry_time = retry_time
+        self.daemon = is_daemon
 
     def run(self):
         retries = 0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,17 +22,6 @@ services:
     depends_on: [consul1, consul2, consul3, consul4]
     command:
       ["tox", "-e", "py36"]
-  integration_tests_py37:
-    build:
-      context: .
-      dockerfile: Dockerfile
-      args:
-        PYTHON_VERSION: 3.7
-    volumes:
-      - .:/src
-    depends_on: [consul1, consul2, consul3, consul4]
-    command:
-      ["tox", "-e", "py37"]
   integration_tests_py38:
     build:
       context: .
@@ -44,17 +33,39 @@ services:
     depends_on: [consul1, consul2, consul3, consul4]
     command:
       ["tox", "-e", "py38"]
-  integration_tests_py39:
+  integration_tests_py310:
     build:
       context: .
       dockerfile: Dockerfile
       args:
-        PYTHON_VERSION: 3.9
+        PYTHON_VERSION: '3.10'
     volumes:
       - .:/src
     depends_on: [consul1, consul2, consul3, consul4]
     command:
-      ["tox", "-e", "py39"]
+      ["tox", "-e", "py310"]
+  integration_tests_py312:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        PYTHON_VERSION: '3.12'
+    volumes:
+      - .:/src
+    depends_on: [consul1, consul2, consul3, consul4]
+    command:
+      ["tox", "-e", "py312"]
+  integration_tests_py314:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        PYTHON_VERSION: '3.14'
+    volumes:
+      - .:/src
+    depends_on: [consul1, consul2, consul3, consul4]
+    command:
+      ["tox", "-e", "py314"]
   consul1:
     image: consul:1.10.0
     ports:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ if not sys.version_info >= (3, 5):
 
 setup(
     name="consul_lib",
-    version="0.1.8",
+    version="0.1.9",
     maintainer="Syseleven Cloudstackers",
     maintainer_email="cloudstackers@syseleven.de",
     url="https://github.com/syseleven/consul_lib",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint, py35, py36, py37, py38, py39, safety
+envlist = lint, py35, py36, py38, py310, py312, py314, safety
 
 [testenv]
 deps =


### PR DESCRIPTION
`SessionRenewer` and `Lock` classes relies on `threading.Thread`, t
This MR will allow us to set the behavior of the `daemon` that belongs to the `Thread` class, by doing this, we can for example kill a thread on script termination



Additionally this PR updates the automation test:

- Now we use the python action to install python for lint and safety checks
- Now we use the docker compose action, to install and configure docker compose
- Updated checkout action to the latest available
